### PR TITLE
Race breakdown in rankings output

### DIFF
--- a/src/krra_race_series/cli.py
+++ b/src/krra_race_series/cli.py
@@ -91,7 +91,8 @@ def main() -> None:
 
     # Export category results
     print(f"\nExporting category standings to {args.output}/...")
-    exporter.export_category_standings(category_standings, args.output)
+    race_names = series.get_race_names()
+    exporter.export_category_standings(category_standings, args.output, race_names)
 
     # Display summary for each category
     print("\nCategory Standings Summary:")


### PR DESCRIPTION
Enhance CSV export functionality to support individual race columns instead of just number of races completed. This applies to both overall and category rankings